### PR TITLE
@onekilo79 - add docker tag for latest and for circleci build number

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,5 @@ test:
   post:
     - docker build --rm=true -t registry.uw.systems/telecom/telecom-kafka:latest .
     - docker tag registry.uw.systems/telecom/telecom-kafka:latest registry.uw.systems:utilitywarehouse/telecom-kafka:$CIRCLE_SHA1
-    - docker push registry.uw.systems/telecom/telecom-kafka
+    - docker push registry.uw.systems/telecom/telecom-kafka:latest
+    - docker push registry.uw.systems/telecom/telecom-kafka:$CIRCLE_BUILD_NUM

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,6 @@ dependencies:
 test:
   post:
     - docker build --rm=true -t registry.uw.systems/telecom/telecom-kafka:latest .
-    - docker tag registry.uw.systems/telecom/telecom-kafka:latest registry.uw.systems:utilitywarehouse/telecom-kafka:$CIRCLE_SHA1
+    - docker tag registry.uw.systems/telecom/telecom-kafka:latest registry.uw.systems:utilitywarehouse/telecom-kafka:$CIRCLE_SHA1 registry.uw.systems/telecom/telecom-kafka:$CIRCLE_BUILD_NUM
     - docker push registry.uw.systems/telecom/telecom-kafka:latest
     - docker push registry.uw.systems/telecom/telecom-kafka:$CIRCLE_BUILD_NUM


### PR DESCRIPTION
This will both tag latest and tag with the circleci build number so projects can rely on a non-moving version