### PR TITLE
Update to v3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG=C.UTF-8 \
     JAVA_HOME=/opt/java/openjdk \
     PATH=${PATH}:/opt/java/openjdk/bin \
     LANG=C.UTF-8 \
-    KAFKA_VERSION="3.0.0" \
+    KAFKA_VERSION="3.1.0" \
     SCALA_VERSION="2.13"
 
 RUN sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ $JAVA_HOME/conf/security/java.security


### PR DESCRIPTION
- https://downloads.apache.org/kafka/3.1.0/RELEASE_NOTES.html
- https://blogs.apache.org/kafka/entry/what-s-new-in-apache7

JDK 17 remains latest